### PR TITLE
Add reusable github actions for Jira issues

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,89 @@
+name: Create Jira Issue
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: The key of the Jira project to create the issue in
+        required: true
+        type: string
+      github_team:
+        description: The name of the GitHub Org team to assign the issue to
+        required: true
+        type: string
+      issue_type:
+        description: The type of issue to create
+        required: false
+        default: Task
+        type: string
+      labels:
+        description: Comma-separated list of labels to apply to the issue
+        required: false
+        default: security, dependabot
+        type: string
+
+jobs:
+  create_jira_issue_for_dependabot_pr:
+    if: github.actor != 'dependabot[bot]' # TODO: Change to == after initial testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # Fetch all history so that we can get the release branch names
+
+      - name: Get release branch names
+        id: get_release_branch_names
+        run: |
+          all_branches=$(git branch -r --format='%(refname:short)')
+          release_branches=$(echo "$all_branches" | grep -E 'release/.*0$' | tr '\n' ',' | sed 's/,$//')
+          echo "release_branches=$release_branches" >> $GITHUB_OUTPUT
+
+      - name: Assign PR to GH team member # Assign PR to a random member of the specified GitHub Org team
+        uses: dc-ag/auto-assign-assignees-from-team@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          read-token: ${{ secrets.READ_ONLY_ORG_TEAM_MEMBERS }} # Read only token which needs access to fetch team members
+          team: ${{ inputs.github_team }}
+          amount: 1 # Amount of assignees to assign
+
+      - name: Get PR assignee # To be used to assign Jira issue to the same person
+        id: get_assignee
+        run: |
+          assignee_object=$(gh pr view ${{ github.event.pull_request.number }} --json assignees --jq '.assignees[0]')
+          assignee_fullname=$(echo "$assignee_object" | jq -r '.name')
+          assignee_firstname=$(echo "$assignee_fullname" | cut -d ' ' -f1)
+          echo "assignee=$assignee_firstname" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Create Jira issue
+        id: create
+        uses: macuject/gajira-create@v1.0.0
+        with:
+          project: ${{ inputs.project }}
+          issuetype: ${{ inputs.issue_type }}
+          summary: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          prlink: ${{ github.event.pull_request._links.html.href }}
+          labels: ${{ inputs.labels }}
+          assignee: ${{ steps.get_assignee.outputs.assignee }}
+          releaseBranches: ${{ steps.get_release_branch_names.outputs.release_branches }}
+
+      - name: Log created issue
+        run: echo "Issue ${{ steps.create.outputs.issue }} was created"
+
+      - name: Rename pull request to include Jira issue number
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --title "${{ steps.create.outputs.issue }}: ${{ github.event.pull_request.title }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           project: ${{ inputs.project }}
           issuetype: ${{ inputs.issue_type }}
+          isSec: true
           summary: ${{ github.event.pull_request.title }}
           body: ${{ github.event.pull_request.body }}
           prlink: ${{ github.event.pull_request._links.html.href }}

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -78,6 +78,7 @@ jobs:
           labels: ${{ inputs.labels }}
           assignee: ${{ steps.get_assignee.outputs.assignee }}
           releaseBranches: ${{ steps.get_release_branch_names.outputs.release_branches }}
+          githubJiraUserMap: ${{ vars.GH_JIRA_USER_MAP }}
 
       - name: Log created issue
         run: echo "Issue ${{ steps.create.outputs.issue }} was created"

--- a/.github/workflows/update-jira-issue.yml
+++ b/.github/workflows/update-jira-issue.yml
@@ -1,0 +1,27 @@
+name: Update Jira Issue
+
+on:
+  workflow_call:
+
+jobs:
+  transition_dependabot_issue_to_done_on_pr_merge:
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.merged == true # TODO: Change to github.actor != 'dependabot[bot]' after initial testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Extract issue key from pull request title
+        id: extract_issue_key
+        run: |
+          echo "issue_key=$(echo ${{ github.event.pull_request.title }} | cut -d ':' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Transition Jira ticket to Done
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.extract_issue_key.outputs.issue_key }}
+          transition: Done


### PR DESCRIPTION
## Description

Adds GitHub Actions for reuse in Web, Platform, ML and other repos across the org. These Actions facilitate creation and transition of Jira issues related to Dependabot PRs.

**Jira**: <https://jira.macuject.com/PF-103>

NOTE: Currently these actions are set to perform on `create` or `merge` of *any* PR, to enable testing that they work. I propose merging like this, performing a test by opening a PR and merging it in the relevant repo (e.g. `web`, and then changing the line `github.actor != 'dependabot[bot]'` to `github.actor == 'dependabot[bot]'` in **both** actions.

NOTE: Needs to be tested in conjunction with:
- https://github.com/macuject/web/pull/382
- https://github.com/macuject/gajira-create/pull/1

## Data

Several GitHub Secrets will need to be set up either against this repo or at Org level. Namely:

- `JIRA_API_TOKEN`: An API Token from Jira
- `JIRA_BASE_URL`: `https://macuject.atlassian.net/` (this could be a variable or secret, but is currently referred to in the code as a secret)
- `JIRA_USER_EMAIL`: An email address for a user who will become the "reporter" of the Jira issues that are created
- `READ_ONLY_ORG_TEAM_MEMBERS`: A GitHub user API key, a `Fine-grained personal access token`, with `read_only` permissions for `Administration`, which is needed to allow reading org team member names.

An Org Variable:
- `GH_JIRA_USER_MAP`: Mapping of GitHub & Jira usernames in JSON format. I will slack you the details of this @bradleybeddoes 

To be discussed with @bradleybeddoes .

## Security

It requires the creation of API keys for both Jira and GitHub. This will be done under the advice of the ISO.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. A summary is provided and full details can be found within our [impact assessment] documentation.

- **High**: Potential for significant harm to sensitive data or user access, and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access, and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to result in significant harm to sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.

**Impact Assessment for this PR**: Low

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] Data related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
