### PR TITLE
PF-103: Explicitly pass secrets from caller action

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -21,6 +21,15 @@ on:
         required: false
         default: security, dependabot
         type: string
+    secrets:
+      JIRA_BASE_URL:
+        required: true
+      JIRA_USER_EMAIL:
+        required: true
+      JIRA_API_TOKEN:
+        required: true
+      READ_ONLY_ORG_TEAM_MEMBERS:
+        required: true
 
 jobs:
   create_jira_issue_for_dependabot_pr:
@@ -40,6 +49,13 @@ jobs:
           release_branches=$(echo "$all_branches" | grep -E 'release/.*0$' | tr '\n' ',' | sed 's/,$//')
           echo "release_branches=$release_branches" >> $GITHUB_OUTPUT
 
+      - name: Log in to Jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
       - name: Assign PR to GH team member # Assign PR to a random member of the specified GitHub Org team
         uses: dc-ag/auto-assign-assignees-from-team@v1
         with:
@@ -57,13 +73,6 @@ jobs:
           echo "assignee=$assignee_firstname" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Jira
-        uses: atlassian/gajira-login@v3
-        env:
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Create Jira issue
         id: create


### PR DESCRIPTION
## Description

Explicitly receive GitHub Secrets from caller action.

**Jira**: <https://jira.macuject.com/PF-103>

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. A summary is provided and full details can be found within our [impact assessment] documentation.

- **High**: Potential for significant harm to sensitive data or user access, and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access, and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to result in significant harm to sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.

**Impact Assessment for this PR**: Low

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] Data related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
