### PR TITLE
PF-103: Shorten action names

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -33,18 +33,24 @@ on:
 
 jobs:
   Create: # Create a new Jira issue when a PR is opened by dependabot, or when a PR is labeled with 'process-existing-pr'
-    if: >- # Specificity is important here to avoid triggering this action multiple times when Dependabot creates then labels a PR
-      (github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'opened') ||
-      (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'process-existing-pr')
     runs-on: ubuntu-latest
     steps:
+      - name: Skip remaining steps # Run this rather than just skipping the whole job, so that we see a green tick in the PR checks
+        if: >- # Specificity is important here to avoid triggering this action multiple times when Dependabot creates then labels a PR
+          !((github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'opened') ||
+            (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'process-existing-pr'))
+        id: skip
+        run: echo "Run not needed for this PR, skipping remaining steps"
+
       - name: Checkout code
+        if: steps.skip.outcome == 'skipped'
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Fetch all history so that we can get the release branch names
 
       - name: Get release branch names
+        if: steps.skip.outcome == 'skipped'
         id: get_release_branch_names
         run: |
           all_branches=$(git branch -r --format='%(refname:short)')
@@ -52,9 +58,11 @@ jobs:
           echo "release_branches=$release_branches" >> $GITHUB_OUTPUT
 
       - name: Log release branch names
+        if: steps.skip.outcome == 'skipped'
         run: echo "Release branch names ${{ steps.get_release_branch_names.outputs.release_branches }}"
 
       - name: Assign PR to GH team member # Assign PR to a random member of the specified GitHub Org team
+        if: steps.skip.outcome == 'skipped'
         uses: dc-ag/auto-assign-assignees-from-team@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,6 +71,7 @@ jobs:
           amount: 1 # Amount of assignees to assign
 
       - name: Get PR assignee # To be used to assign Jira issue to the same person
+        if: steps.skip.outcome == 'skipped'
         id: get_assignee
         run: |
           assignee_object=$(gh pr view ${{ github.event.pull_request.number }} --json assignees --jq '.assignees[0]')
@@ -72,6 +81,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Jira
+        if: steps.skip.outcome == 'skipped'
         uses: atlassian/gajira-login@v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
@@ -79,6 +89,7 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
       - name: Create Jira issue
+        if: steps.skip.outcome == 'skipped'
         id: create
         uses: macuject/gajira-create@v1.0.0
         with:
@@ -94,15 +105,18 @@ jobs:
           githubJiraUserMap: ${{ vars.GH_JIRA_USER_MAP }}
 
       - name: Transition Jira issue to In Review
+        if: steps.skip.outcome == 'skipped'
         uses: atlassian/gajira-transition@v3
         with:
           issue: ${{ steps.create.outputs.issue }}
           transition: In Review
 
       - name: Log created issue
+        if: steps.skip.outcome == 'skipped'
         run: echo "Issue ${{ steps.create.outputs.issue }} was created"
 
       - name: Rename pull request to include Jira issue number
+        if: steps.skip.outcome == 'skipped'
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --title "${{ steps.create.outputs.issue }}: ${{ github.event.pull_request.title }}"
@@ -110,6 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Jira issue link as comment on PR
+        if: steps.skip.outcome == 'skipped'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "Associated Jira issue: https://macuject.atlassian.net/browse/${{ steps.create.outputs.issue }}"

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -51,6 +51,9 @@ jobs:
           release_branches=$(echo "$all_branches" | grep -E 'release/.*0$' | tr '\n' ',' | sed 's/,$//')
           echo "release_branches=$release_branches" >> $GITHUB_OUTPUT
 
+      - name: Log release branch names
+        run: echo "Release branch names ${{ steps.get_release_branch_names.outputs.release_branches }}"
+
       - name: Assign PR to GH team member # Assign PR to a random member of the specified GitHub Org team
         uses: dc-ag/auto-assign-assignees-from-team@v1
         with:

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,4 +1,4 @@
-name: Create Jira Issue
+name: Jira
 
 on:
   workflow_call:
@@ -32,7 +32,7 @@ on:
         required: true
 
 jobs:
-  create_jira_issue_for_dependabot_pr:
+  Create: # Create a new Jira issue when a PR is opened by dependabot, or when a PR is labeled with 'process-existing-pr'
     if: >- # Specificity is important here to avoid triggering this action multiple times when Dependabot creates then labels a PR
       (github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'opened') ||
       (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'process-existing-pr')


### PR DESCRIPTION
## Description

- Shortens the name of the GitHub action to declutter the GitHub interface when it's run
- Also adds logging of release branch names to assist in debugging why the FixVersion isn't getting assigned in Jira

**Jira**: https://macuject.atlassian.net/browse/PF-103

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. A summary is provided and full details can be found within our [impact assessment] documentation.

- **High**: Potential for significant harm to sensitive data or user access, and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access, and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to result in significant harm to sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.

**Impact Assessment for this PR**: Low

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] Data related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
