### PR TITLE
Add sections for Breaking Changes and UAT

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -35,11 +35,11 @@ Delete me: Does this PR add/update/remove anything that is considered a 'job' e.
 
 ## Impact Assessment
 
-As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. A summary is provided and full details can be found within our [impact assessment] documentation.
+As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.
 
-- **High**: Potential for significant harm to sensitive data or user access, and material adverse impact on Macuject's operations or reputation.
-- **Medium**: Potential for moderate harm to sensitive data or user access, and adverse impact on Macuject's operations or reputation.
-- **Low**: Unlikely to result in significant harm to sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
+- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
+- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
+- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
 - **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.
 
 **Impact Assessment for this PR**: [High/Medium/Low/None]
@@ -56,7 +56,7 @@ I've considered all of the following and added details to the PR description whe
 
 - [ ] Breaking changes
 - [ ] UAT guidance
-- [ ] Data related changes
+- [ ] Data-related changes
 - [ ] Job(s) have been described and a [PR opened][job process] for the platform team to review
 - [ ] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,10 @@ Delete me: If applicable, add screenshots to help explain this PR's changes. If 
 | Wide screen  | IMG    | IMG   |
 | Small screen | IMG    | IMG   |
 
+## UAT
+
+Delete me: Does this PR require UAT e.g. by the product or medical team? If so, please describe the testing required and undertaken. If not needed delete this entire section.
+
 ## Data
 
 Delete me: Does this PR require database, data migration or data flow change? Describe the changes required and testing undertaken. If not needed delete this entire section.
@@ -46,6 +50,7 @@ I've considered all of the following and added to the proposed changes where rel
 I've considered all of the following and added details to the PR description where relevant:
 
 - [ ] Breaking changes
+- [ ] UAT guidance
 - [ ] Data related changes
 - [ ] Job(s) have been described and a [PR opened][job process] for the platform team to review
 - [ ] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -40,8 +40,9 @@ As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA
 - **High**: Potential for significant harm to sensitive data or user access, and material adverse impact on Macuject's operations or reputation.
 - **Medium**: Potential for moderate harm to sensitive data or user access, and adverse impact on Macuject's operations or reputation.
 - **Low**: Unlikely to result in significant harm to sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
+- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.
 
-**Impact Assessment for this PR**: [High/Medium/Low]
+**Impact Assessment for this PR**: [High/Medium/Low/None]
 
 ## Checklist
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
+**Jira**: https://macuject.atlassian.net/browse/[ID]
+
 ## Description
 
-Delete me: Describe the changes in this PR. Please explicitly note any breaking changes.
+Delete me: Describe the changes in this PR.
 
-**Jira**: https://macuject.atlassian.net/browse/[ID]
+### Breaking Changes
+
+Delete me: If applicable, describe any breaking changes. If not needed delete this entire section.
 
 ## Screenshots / Videos
 


### PR DESCRIPTION
## Description

PR template updates.

Sections have been added to the template in actual PR, providing additional context for understanding the proposed change.

Minor wording changes.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.

- **High**: Potential for significant harm to sensitive data or user access and adversely impacting Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.

**Impact Assessment for this PR**: Low

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
