### PR TITLE
PF-178: Fix assign reviewer in GH action

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -61,24 +61,22 @@ jobs:
         if: steps.skip.outcome == 'skipped'
         run: echo "Release branch names ${{ steps.get_release_branch_names.outputs.release_branches }}"
 
-      - name: Get random github team member from specified team
+      - name: Assign PR to GH team member # Assign PR to a random member of the specified GitHub Org team
         if: steps.skip.outcome == 'skipped'
-        id: get_random_github_team_member
-        run: |
-          MEMBERS=$(curl -s -H "Authorization: token ${{ secrets.READ_ONLY_ORG_TEAM_MEMBERS }}" \
-          "https://api.github.com/orgs/macuject/teams/${{ inputs.github_team }}/members")
-          RANDOM_MEMBER=$(echo "$MEMBERS" | jq -r '.[] | .login' | shuf -n 1)
-          echo "random_team_member=$RANDOM_MEMBER" >> $GITHUB_OUTPUT
+        uses: dc-ag/auto-assign-assignees-from-team@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          read-token: ${{ secrets.READ_ONLY_ORG_TEAM_MEMBERS }} # Read only token which needs access to fetch team members
+          team: ${{ inputs.github_team }}
+          amount: 1 # Amount of assignees to assign
 
-      - name: Log random github team member
+      - name: Get PR assignee # To be used to assign Jira issue to the same person
         if: steps.skip.outcome == 'skipped'
-        run: echo "Random GitHub team member ${{ steps.get_random_github_team_member.outputs.random_team_member }}"
-
-      - name: Assign random github team member as reviewer
-        if: steps.skip.outcome == 'skipped'
+        id: get_assignee
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --add-reviewer ${{ steps.get_random_github_team_member.outputs.random_team_member }}
+          assignee_object=$(gh pr view ${{ github.event.pull_request.number }} --json assignees --jq '.assignees[0]')
+          assignee_username=$(echo "$assignee_object" | jq -r '.login')
+          echo "assignee=$assignee_username" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -102,7 +100,7 @@ jobs:
           body: ${{ github.event.pull_request.body }}
           prlink: ${{ github.event.pull_request._links.html.href }}
           labels: ${{ inputs.labels }}
-          assignee: ${{ steps.get_random_github_team_member.outputs.random_team_member }}
+          assignee: ${{ steps.get_assignee.outputs.assignee }}
           releaseBranches: ${{ steps.get_release_branch_names.outputs.release_branches }}
           githubJiraUserMap: ${{ vars.GH_JIRA_USER_MAP }}
 

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -61,22 +61,24 @@ jobs:
         if: steps.skip.outcome == 'skipped'
         run: echo "Release branch names ${{ steps.get_release_branch_names.outputs.release_branches }}"
 
-      - name: Assign PR to GH team member # Assign PR to a random member of the specified GitHub Org team
+      - name: Assign GH team member as reviewer # Assign a random member of the specified GitHub Org team as reviewer
         if: steps.skip.outcome == 'skipped'
-        uses: dc-ag/auto-assign-assignees-from-team@v1
+        uses: dc-ag/auto-assign-reviewer-from-team@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           read-token: ${{ secrets.READ_ONLY_ORG_TEAM_MEMBERS }} # Read only token which needs access to fetch team members
           team: ${{ inputs.github_team }}
-          amount: 1 # Amount of assignees to assign
+          amount: 1 # Amount of reviewers to assign
 
-      - name: Get PR assignee # To be used to assign Jira issue to the same person
+      - name: Get PR reviewer # To be used to assign Jira issue to the same person
         if: steps.skip.outcome == 'skipped'
-        id: get_assignee
-        run: |
-          assignee_object=$(gh pr view ${{ github.event.pull_request.number }} --json assignees --jq '.assignees[0]')
-          assignee_username=$(echo "$assignee_object" | jq -r '.login')
-          echo "assignee=$assignee_username" >> $GITHUB_OUTPUT
+        id: get_reviewer
+        run: | # Use the first reviewer request (PR not yet reviewed), or if none, the first review (PR already reviewed)
+          reviewer_username=$(gh pr view ${{ github.event.pull_request.number }} --json reviewRequests --jq '.reviewRequests[0].login')
+          if [[ -z "$reviewer_username" ]]; then
+            reviewer_username=$(gh pr view ${{ github.event.pull_request.number }} --json reviews --jq '.reviews[0].author.login')
+          fi
+          echo "reviewer=$reviewer_username" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -100,7 +102,7 @@ jobs:
           body: ${{ github.event.pull_request.body }}
           prlink: ${{ github.event.pull_request._links.html.href }}
           labels: ${{ inputs.labels }}
-          assignee: ${{ steps.get_assignee.outputs.assignee }}
+          assignee: ${{ steps.get_reviewer.outputs.reviewer }}
           releaseBranches: ${{ steps.get_release_branch_names.outputs.release_branches }}
           githubJiraUserMap: ${{ vars.GH_JIRA_USER_MAP }}
 

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Assign GH team member as reviewer # Assign a random member of the specified GitHub Org team as reviewer
         if: steps.skip.outcome == 'skipped'
-        uses: dc-ag/auto-assign-reviewer-from-team@v1
+        uses: dc-ag/auto-assign-reviewers-from-team@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           read-token: ${{ secrets.READ_ONLY_ORG_TEAM_MEMBERS }} # Read only token which needs access to fetch team members


### PR DESCRIPTION
**Jira**: https://macuject.atlassian.net/browse/PF-178

## Description

(Hopefully) fixes the error that we are now getting when applying the `process-existing-pr` label on a Dependabot PR.

- Reverted the commit that introduced the issue with org permissions for assigning a reviewer
- Used an existing GH Action that should work with org repos
- Updated the bash script to get reviewer to assign Jira ticket to
  - If the PR hasn't yet been reviewed (as will usually be the case when this Action is run), gets the username of the first `requestedReviewer`
  - If for some reason the PR has already been reviewed when this Action is being run (e.g. running on a closed PR to create the Jira ticket etc), it gets the username of the first `Reviewer`

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
