### PR TITLE
PF-273: Allow specifying team members to NOT review

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -11,6 +11,10 @@ on:
         description: The name of the GitHub Org team to assign the issue to
         required: true
         type: string
+      dependabot_exclude_team_members:
+        description: Comma-separated list of team members to exclude from being assigned as reviewer when Dependabot opens a PR
+        required: false
+        type: string
       issue_type:
         description: The type of issue to create
         required: false
@@ -61,16 +65,33 @@ jobs:
         if: steps.skip.outcome == 'skipped'
         run: echo "Release branch names ${{ steps.get_release_branch_names.outputs.release_branches }}"
 
+      # Prevent dependency conflicts
+      - name: Delete current_repo
+        run: rm -rf current_repo
+
+      - name: Checkout code from macuject/.github repo
+        uses: actions/checkout@v3
+        with:
+          repository: macuject/.github
+          path: reusable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install node-fetch dotenv
+        working-directory: reusable
+
       - name: Assign GH team member as reviewer # Assign a random member of the specified GitHub Org team as reviewer
         if: steps.skip.outcome == 'skipped'
-        uses: dc-ag/auto-assign-reviewers-from-team@v1.3.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          admin-repo-token: ${{ secrets.ORG_TEAM_MEMBERS }} # GitHub Personal Access Token that has 'repo' rights
-          team: ${{ inputs.github_team }}
-          amount: 1 # Amount of reviewers to assign
-          use-team-reviewer-settings: false # Set to true if you want to use the team's reviewer settings instead of a specific amount
-          ignore-branches-regex: "" # Regex to check branches. If matched the PR won't be assigned any reviewers via this workflow
+        run: node reusable/.github/workflows/assign-reviewer.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TEAM: ${{ inputs.github_team }}
+          AMOUNT: 1
+          EXCLUDE_MEMBERS: ${{ inputs.dependabot_exclude_team_members }}
 
       - name: Get PR reviewer # To be used to assign Jira issue to the same person
         if: steps.skip.outcome == 'skipped'

--- a/assign-reviewer.mjs
+++ b/assign-reviewer.mjs
@@ -1,0 +1,109 @@
+// Adapted from https://github.com/dc-ag/auto-assign-reviewers-from-team/blob/main/src/main.ts
+// to allow excluding specific team members from the list of potential reviewers
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+
+async function run() {
+  try {
+    const repoToken = process.env.GITHUB_TOKEN;
+    const team = process.env.GITHUB_TEAM;
+    const amount = parseInt(process.env.AMOUNT);
+    const excludeMembers = process.env.EXCLUDE_MEMBERS
+      ? process.env.EXCLUDE_MEMBERS.split(",")
+      : [];
+
+    const issue = github.context.issue;
+
+    if (!issue || !issue.number) {
+      console.log("No pull request context, skipping!");
+      return;
+    }
+
+    const ghOrg = github.context.repo.owner;
+    const octokit = github.getOctokit(repoToken);
+
+    const pullRequest = await octokit.rest.pulls.get({
+      owner: issue.owner,
+      repo: issue.repo,
+      pull_number: issue.number,
+    });
+
+    if (!pullRequest) {
+      console.log("Pull request not found, skipping!");
+      return;
+    }
+
+    const members = await octokit.rest.teams.listMembersInOrg({
+      org: ghOrg,
+      team_slug: team,
+    });
+
+    let memberNames = members.data.map((a) => a.login);
+
+    // Exclude PR author and members from the exclude list
+    memberNames = memberNames.filter(
+      (name) =>
+        name !== pullRequest.data.user?.login &&
+        !excludeMembers.includes(name)
+    );
+
+    console.log(`Picking ${amount} reviewer(s) from members: `, memberNames);
+
+    let finalReviewers = [];
+
+    if (amount === 0 || memberNames.length <= amount) {
+      finalReviewers = memberNames;
+    } else {
+      memberNames = shuffle(memberNames);
+      for (let i = 0; i < amount; i++) {
+        const name = memberNames.pop();
+        if (name !== undefined) {
+          finalReviewers.push(name);
+        }
+      }
+    }
+
+    if (finalReviewers.length > 0) {
+      const reviewerResponse = await octokit.rest.pulls.requestReviewers({
+        owner: issue.owner,
+        repo: issue.repo,
+        pull_number: issue.number,
+        reviewers: finalReviewers,
+      });
+      console.log(
+        `Request Status for assigning reviewers: ${reviewerResponse.status}`
+      );
+      console.log(
+        `Reviewers from Team '${team}' for PR ${issue.number}: ${reviewerResponse?.data?.requested_reviewers
+          ?.map((r) => r.login)
+          .join(",")}`
+      );
+      console.log("... success!");
+    } else {
+      console.log(`No members to assign found in team ${team}`);
+    }
+  } catch (error) {
+    console.error(error);
+    core.setFailed(`Error: ${error}`);
+    throw error;
+  }
+}
+
+function shuffle(array) {
+  let currentIndex = array.length,
+    randomIndex;
+
+  while (currentIndex != 0) {
+    randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex],
+      array[currentIndex],
+    ];
+  }
+
+  return array;
+}
+
+run();


### PR DESCRIPTION
**Jira**: https://macuject.atlassian.net/browse/PF-273

## Description

Allows specifying a list of GH users to exclude from the list of potential reviewers for dependabot PRs.

Previously we were using an existing GH Action to handle assigning a reviewer (https://github.com/dc-ag/auto-assign-reviewers-from-team/tree/main), however this didn't allow for excluding individual team members from potentially being assigned. This PR introduces a script based on the `dc-ag` GH Action which adds the functionality we need and strips out some we don't. It leaves in some things like assigning multiple reviewers, because we may want that in future and it's harmless to leave in.

Noting that this is impossible to properly check it works - it may very well fail the next time we get a dependabot PR. But I'm as confident as I can be that it will succeed.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
