### PR TITLE
PF-249: GH Actions release script Bugfix

### DIFF
--- a/.github/workflows/release-version.mjs
+++ b/.github/workflows/release-version.mjs
@@ -29,7 +29,6 @@ const fetchCurrentFixVersions = async () => {
 
 const fetchUnreleasedJiraFixVersions = async () => {
   const response = await fetch(`${JIRA_BASE_URL}/rest/api/3/project/${PROJECT_KEY}/version?status=unreleased&orderBy=name`, {
-  // const response = await fetch(`${JIRA_BASE_URL}/rest/api/3/project/${PROJECT_KEY}/versions`, {
     method: 'GET',
     headers: {
       'Authorization': `Basic ${Buffer.from(
@@ -91,7 +90,7 @@ const fetchAndCompare = async () => {
         console.error('Release branch number not found in Jira fixVersions. Unclear how to proceed, so returning early.');
         process.exit(1);
       }
-    }  else if (github_release_branches.length > 0) {
+    } else if (github_release_branches.length > 0) {
         // Get the release branch numbers from the Github release branches
         github_release_branches = github_release_branches.split(',').map(item => {
           // Release branch names ommit the patch version number, so add it back in

--- a/.github/workflows/release-version.mjs
+++ b/.github/workflows/release-version.mjs
@@ -91,20 +91,14 @@ const fetchAndCompare = async () => {
         console.error('Release branch number not found in Jira fixVersions. Unclear how to proceed, so returning early.');
         process.exit(1);
       }
-    }  else {
-      // Get the release branch numbers from the Github release branches
-      github_release_branches = github_release_branches.split(',').map(item => {
-        // Release branch names ommit the patch version number, so add it back in
-        return item.trim().substring(item.length - 4) + '.0';
-      })
-      const githubReleaseBranchNumbers = sortVersionsDescending(github_release_branches);
+    }  else if (github_release_branches.length > 0) {
+        // Get the release branch numbers from the Github release branches
+        github_release_branches = github_release_branches.split(',').map(item => {
+          // Release branch names ommit the patch version number, so add it back in
+          return item.trim().substring(item.length - 4) + '.0';
+        })
+        const githubReleaseBranchNumbers = sortVersionsDescending(github_release_branches);
 
-      if (githubReleaseBranchNumbers === 0) {
-        // If there are no release branches, use the lowest Jira version number as the correct fixVersion
-        correctFixVersion = unreleasedJiraFixVersions[0];
-        console.log('No release branches found. Using the lowest unreleased Jira version number as the correct fixVersion.')
-        console.log('Correct fixVersion:', correctFixVersion);
-      } else {
         console.log('All unreleased fixVersions in the Jira project:', unreleasedJiraFixVersions);
         console.log('Github release branches:', githubReleaseBranchNumbers);
         console.log('Currently assigned fixVersion for Jira ticket:', predictedFixVersion);
@@ -114,6 +108,11 @@ const fetchAndCompare = async () => {
 
         // Find the lowest Jira version number that is higher than the highest release branch number
         correctFixVersion = unreleasedJiraFixVersions.find(item => item > highestReleaseBranchNum)
+        console.log('Correct fixVersion:', correctFixVersion);
+      } else {
+        // If there are no release branches, use the lowest Jira version number as the correct fixVersion
+        correctFixVersion = unreleasedJiraFixVersions[0];
+        console.log('No release branches found. Using the lowest unreleased Jira version number as the correct fixVersion.')
         console.log('Correct fixVersion:', correctFixVersion);
       }
     }


### PR DESCRIPTION
**Jira**: https://macuject.atlassian.net/browse/PF-249

## Description

When there are 0 release branches on GitHub, the script was incorrectly creating one listed as ".0" and then attempting to use that in the logic.

Adds a check to only process based on release branches if there are any.

This wasn't a dependabot-specific bug, it just happened to become apparent with two dependabot PRs on the same day, under the rare condition that there was no release branch in GitHub and two unpublished releases in Jira.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
