### PR TITLE
PF-311: Update gajira-create version used in GH action

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Create Jira issue
         if: steps.skip.outcome == 'skipped'
         id: create
-        uses: macuject/gajira-create@v1.0.0
+        uses: macuject/gajira-create@1.0.1
         with:
           project: ${{ inputs.project }}
           issuetype: ${{ inputs.issue_type }}


### PR DESCRIPTION
## Description

Updates the `gajira-create` version used in GH action, to accompany the new version of that action published in https://github.com/macuject/gajira-create which includes changes to Security Epic transitions.

These changes were not being applied because the GH action is pointing to an older version of the code. Reminder added to that repo [here](https://github.com/macuject/gajira-create/pull/24) to avoid repeating this mistake.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
