### PR TITLE
WA-1784: Update gajira-create to 1.0.2

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Create Jira issue
         if: steps.skip.outcome == 'skipped'
         id: create
-        uses: macuject/gajira-create@1.0.1
+        uses: macuject/gajira-create@1.0.2
         with:
           project: ${{ inputs.project }}
           issuetype: ${{ inputs.issue_type }}


### PR DESCRIPTION
## Summary

- Bumps `macuject/gajira-create` from 1.0.1 to 1.0.2 in the `create-jira-issue.yml` reusable workflow
- v1.0.2 fixes the deprecated `GET /rest/api/3/search` endpoint (Atlassian now returns 410 Gone) by migrating to `POST /rest/api/3/search/jql`
- This restores automatic Jira ticket creation for Dependabot PRs, which has been broken since ~Sep 30, 2025

## Context

See [macuject/gajira-create#30](https://github.com/macuject/gajira-create/pull/30) for the underlying fix.

## Test plan (for after merge of this PR)

- [ ] Merge and trigger via a new Dependabot PR or by adding the `process-existing-pr` label to an existing one
- [ ] Verify Jira ticket is created, PR is renamed, and comment is added

Jira: [WA-1784](https://macuject.atlassian.net/browse/WA-1784)

[WA-1784]: https://macuject.atlassian.net/browse/WA-1784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ