### PR TITLE
WA-1825: Add PR close comment about manual Jira transition

### DIFF
--- a/.github/workflows/update-jira-issue.yml
+++ b/.github/workflows/update-jira-issue.yml
@@ -205,3 +205,20 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           ORG_TEAM_MEMBERS: ${{ secrets.ORG_TEAM_MEMBERS }} # GitHub Personal Access Token that has 'repo' and 'workflow' rights
           REPO_NAME: ${{ github.event.repository.name }}
+
+  # On close without merge (any author)
+  # - Post a comment reminding the author to manually update Jira if the work is abandoned
+  notify_manual_jira_transition_on_close:
+    if: github.event.pull_request.merged == false # PR is closed without merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR about manual Jira transition
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: 'This PR was closed without being merged. The linked Jira issue(s) have **not** been automatically transitioned.\n\nIf this work is abandoned, please manually move the Jira issue to "Won\'t Progress". If you\'re replacing this PR with a new one, no action is needed.'
+            });


### PR DESCRIPTION
## Description

See parent epic https://macuject.atlassian.net/browse/WA-1706 for context.

Adds a new job `notify_manual_jira_transition_on_close` to the reusable `update-jira-issue.yml` workflow. When a PR is closed without being merged, a comment is posted reminding the author that the linked Jira issue(s) have not been automatically transitioned, and advising them to manually move the issue to "Won't Progress" if the work is abandoned.

The job:
- Triggers on `merged == false` (closed without merge), complementing the existing `merged == true` jobs
- Uses `actions/github-script@v7` for a lightweight single API call (no checkout or Node setup needed)
- Applies to all PRs regardless of author (including Dependabot) — the message accounts for PR replacements ("no action needed")

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI