### PR TITLE
Update impact assessment link to Confluence and improve visibility

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -56,7 +56,9 @@ Delete me: Does this PR add/update/remove anything that is considered a 'job' e.
 
 ## Impact Assessment
 
-As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken. Our [impact assessment] documentation contains a summary and complete details.
+As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.
+
+> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**
 
 - **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
 - **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
@@ -82,4 +84,4 @@ I've considered all of the following and added details to the PR description whe
 - [ ] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.
 
 [job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
-[impact assessment]: https://docs.google.com/document/d/1MSPJaPb9LaLvJEH6PIaRULBcz7IaODjRuE6_9hlhHMI
+[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating


### PR DESCRIPTION
## Summary

- Updated the Impact Assessment Rating link in the PR template from the old Google Docs URL to the new Confluence page, as the document was recently migrated to Confluence
- Added a prominent blockquote callout directing PR authors to review the Impact Assessment Rating guide before selecting their rating, making it harder to overlook

## Test plan

- [x] Verify the [Impact Assessment Rating](https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating) Confluence link resolves correctly
- [x] Confirm the blockquote renders visibly in the GitHub PR template preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BB: New format renders fine

<img width="1237" height="422" alt="Screenshot 2026-02-16 at 10 35 04 am" src="https://github.com/user-attachments/assets/66c19775-638a-4318-a5a5-e32f61b8d2c6" />
