### PR TITLE
WA-1864: Automate Jira transitions on PR open and ready for review

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -139,6 +139,20 @@ jobs:
           releaseBranches: ${{ steps.get_release_branch_names.outputs.release_branches }}
           githubJiraUserMap: ${{ vars.GH_JIRA_USER_MAP }}
 
+      - name: Transition Jira issue to Ready
+        if: steps.skip.outcome == 'skipped'
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.create.outputs.issue }}
+          transition: Ready
+
+      - name: Transition Jira issue to In Progress
+        if: steps.skip.outcome == 'skipped'
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.create.outputs.issue }}
+          transition: In Progress
+
       - name: Transition Jira issue to In Review
         if: steps.skip.outcome == 'skipped'
         uses: atlassian/gajira-transition@v3

--- a/.github/workflows/transition-jira-to-in-review.yml
+++ b/.github/workflows/transition-jira-to-in-review.yml
@@ -1,0 +1,55 @@
+# Transitions a Jira issue to "In Review" when a non-dependabot PR is opened (non-draft) or marked ready for review.
+# Extracts the Jira issue key from the PR branch name.
+name: Transition Jira to In Review
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: 'Jira project key (e.g. WA)'
+        required: true
+        type: string
+    secrets:
+      JIRA_BASE_URL:
+        required: true
+      JIRA_USER_EMAIL:
+        required: true
+      JIRA_API_TOKEN:
+        required: true
+
+jobs:
+  Transition:
+    # Only run for non-dependabot PRs that are ready for review:
+    # - opened as non-draft, OR
+    # - converted from draft to ready for review
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue key from branch name
+        id: extract_key
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          PROJECT="${{ inputs.project }}"
+          ISSUE_KEY=$(echo "$BRANCH" | grep -oE "${PROJECT}-[0-9]+" | head -1)
+          if [[ -z "$ISSUE_KEY" ]]; then
+            echo "No issue key found in branch name: $BRANCH"
+          else
+            echo "issue_key=$ISSUE_KEY" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log in to Jira
+        if: steps.extract_key.outputs.issue_key != ''
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Transition Jira issue to In Review
+        if: steps.extract_key.outputs.issue_key != ''
+        uses: atlassian/gajira-transition@v3
+        with:
+          issue: ${{ steps.extract_key.outputs.issue_key }}
+          transition: In Review

--- a/.github/workflows/transition-jira-to-in-review.yml
+++ b/.github/workflows/transition-jira-to-in-review.yml
@@ -34,7 +34,7 @@ jobs:
           PROJECT="${{ inputs.project }}"
           ISSUE_KEY=$(echo "$BRANCH" | grep -oE "${PROJECT}-[0-9]+" | head -1)
           if [[ -z "$ISSUE_KEY" ]]; then
-            echo "No issue key found in branch name: $BRANCH"
+            echo "::warning::No Jira issue key found in branch name: $BRANCH"
           else
             echo "issue_key=$ISSUE_KEY" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Description

Closes two gaps in Jira status transition automation for PR events:

**Dependabot PRs** (`create-jira-issue.yml`):
- Added intermediate transitions (Backlog → Ready → In Progress) before the existing In Review transition. Previously the workflow tried to jump directly from Backlog to In Review, which fails because Jira requires stepping through intermediate statuses.

**Non-dependabot PRs** (new `transition-jira-to-in-review.yml`):
- New reusable workflow that transitions a Jira issue from In Progress to In Review when a non-dependabot PR is opened as non-draft or converted from draft to ready for review. Extracts the issue key from the PR branch name and emits a warning annotation if no key is found.

Consuming repos must call the new workflow on `pull_request` events with types `[opened, ready_for_review]` and pass the `project` input and Jira secrets. See macuject/web for the corresponding calling workflow change.
- https://github.com/macuject/template/pull/6
- https://github.com/macuject/web/pull/1583
- https://github.com/macuject/platform/pull/405
- https://github.com/macuject/box/pull/34
- Are there any other repos using this that you are aware of @bradleybeddoes which use this and that I may not have access to?

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating