### PR TITLE
WA-1865: Add idempotent transitions and transition_name input

### DIFF
--- a/.github/workflows/transition-jira-to-in-review.yml
+++ b/.github/workflows/transition-jira-to-in-review.yml
@@ -1,5 +1,13 @@
 # Transitions a Jira issue to "In Review" when a non-dependabot PR is opened (non-draft) or marked ready for review.
 # Extracts the Jira issue key from the PR branch name.
+#
+# Calling repos must provide the transition_name for their Jira project. This is the name of the
+# transition (the arrow label in the workflow), NOT the target status (the column name).
+# For example, in the WA project the transition name is "Implementation completed" and the target
+# status is "In Review". To find your project's transition name:
+#   1. Jira REST API: GET /rest/api/3/issue/{ISSUE-KEY}/transitions — find the transition whose
+#      "to.name" is "In Review" and use its "name" field
+#   2. Jira board: Board → Settings → Workflows — the labels on the arrows between statuses
 name: Transition Jira to In Review
 
 on:
@@ -8,6 +16,18 @@ on:
       project:
         description: 'Jira project key (e.g. WA)'
         required: true
+        type: string
+      transition_name:
+        description: >-
+          The Jira transition name to execute (e.g. "Implementation completed").
+          This is the transition name, not the target status name — see workflow header comment
+          for how to find it.
+        required: true
+        type: string
+      target_status:
+        description: 'Target status to check against — skip transition if issue is already in this status (default: In Review)'
+        required: false
+        default: 'In Review'
         type: string
     secrets:
       JIRA_BASE_URL:
@@ -47,9 +67,23 @@ jobs:
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
-      - name: Transition Jira issue to In Review
+      - name: Check current issue status
         if: steps.extract_key.outputs.issue_key != ''
+        id: check_status
+        run: |
+          CURRENT_STATUS=$(curl -s -u "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \
+            "${{ secrets.JIRA_BASE_URL }}/rest/api/3/issue/${{ steps.extract_key.outputs.issue_key }}?fields=status" \
+            | jq -r '.fields.status.name')
+          echo "current_status=$CURRENT_STATUS" >> $GITHUB_OUTPUT
+          if [[ "$CURRENT_STATUS" == "${{ inputs.target_status }}" ]]; then
+            echo "::notice::Issue ${{ steps.extract_key.outputs.issue_key }} is already in '${{ inputs.target_status }}' — skipping transition"
+          fi
+
+      - name: Transition Jira issue to In Review
+        if: >-
+          steps.extract_key.outputs.issue_key != '' &&
+          steps.check_status.outputs.current_status != inputs.target_status
         uses: atlassian/gajira-transition@v3
         with:
           issue: ${{ steps.extract_key.outputs.issue_key }}
-          transition: In Review
+          transition: ${{ inputs.transition_name }}


### PR DESCRIPTION
## Description

Follow-up from WA-1864. Updates the `transition-jira-to-in-review.yml` reusable workflow with two improvements:

1. **Idempotent transitions** — fetches the issue's current status via the Jira REST API before attempting the transition. If the issue is already in the target status (default "In Review"), the transition is skipped with a notice annotation instead of failing.

2. **Explicit transition name** — adds a required `transition_name` input so calling repos specify the Jira transition by its actual name (e.g. "Implementation completed") instead of the workflow hardcoding a status name. Includes header documentation explaining how transition names differ from status names and how to find them.

**New inputs:**
- `transition_name` (required) — the Jira transition name to execute
- `target_status` (optional, default "In Review") — skip transition if issue is already in this status

**Companion PRs** (all depend on this PR merging first):
- macuject/template#7 — template with docs on finding transition names
- macuject/web#1584 — passes `transition_name: 'Implementation completed'`
- macuject/platform#411 — passes `transition_name: 'Ready for review'`
- macuject/box#35 — passes `transition_name: 'In Review'`

## Impact Assessment

**Impact Assessment for this PR**: None

## Checklist

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates