### PR TITLE
WA-1884: Update shared workflow comments for global Jira transitions

### DIFF
--- a/.github/workflows/transition-jira-to-in-review.yml
+++ b/.github/workflows/transition-jira-to-in-review.yml
@@ -1,13 +1,9 @@
 # Transitions a Jira issue to "In Review" when a non-dependabot PR is opened (non-draft) or marked ready for review.
 # Extracts the Jira issue key from the PR branch name.
 #
-# Calling repos must provide the transition_name for their Jira project. This is the name of the
-# transition (the arrow label in the workflow), NOT the target status (the column name).
-# For example, in the WA project the transition name is "Implementation completed" and the target
-# status is "In Review". To find your project's transition name:
-#   1. Jira REST API: GET /rest/api/3/issue/{ISSUE-KEY}/transitions — find the transition whose
-#      "to.name" is "In Review" and use its "name" field
-#   2. Jira board: Board → Settings → Workflows — the labels on the arrows between statuses
+# Jira boards use global transitions where transition names equal the target status name
+# (e.g. the transition to "In Review" is named "In Review"). The transition_name input
+# defaults to "In Review" and should not need to be overridden in most cases.
 name: Transition Jira to In Review
 
 on:
@@ -19,10 +15,10 @@ on:
         type: string
       transition_name:
         description: >-
-          The Jira transition name to execute (e.g. "Implementation completed").
-          This is the transition name, not the target status name — see workflow header comment
-          for how to find it.
-        required: true
+          The Jira transition name to execute. With global transitions this equals
+          the target status name (e.g. "In Review").
+        required: false
+        default: 'In Review'
         type: string
       target_status:
         description: 'Target status to check against — skip transition if issue is already in this status (default: In Review)'


### PR DESCRIPTION
## Description

Update the shared `transition-jira-to-in-review.yml` workflow comments and input descriptions to reflect the switch to global Jira transitions.

**Changes:**
- Simplified header comments — removed old explanation about transition names differing from status names
- Removed instructions for looking up "arrow label" transition names via REST API or board settings
- Updated `transition_name` input description and example to use `"In Review"`
- Added `default: 'In Review'` for `transition_name` (now universal across projects), making the input optional

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [ ] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating