### PR TITLE
PF-661: Bump gajira-create to 1.0.3

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Create Jira issue
         if: steps.skip.outcome == 'skipped'
         id: create
-        uses: macuject/gajira-create@1.0.2
+        uses: macuject/gajira-create@1.0.3
         with:
           project: ${{ inputs.project }}
           issuetype: ${{ inputs.issue_type }}


### PR DESCRIPTION
## Description

Bumps `macuject/gajira-create` from `1.0.2` to `1.0.3` in the reusable Jira issue creation workflow.

Version `1.0.3` hardens `checkAndTransitionSecurityEpics` against missing/undefined fields from Jira API responses, fixing CI failures on Dependabot PRs (e.g. macuject/platform#466, macuject/platform#468).

Depends on: https://github.com/macuject/gajira-create/pull/34 (must be merged and tagged `1.0.3` first)

Jira: [PF-661](https://macuject.atlassian.net/browse/PF-661)

## Impact Assessment

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating

[PF-661]: https://macuject.atlassian.net/browse/PF-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ