### PR TITLE
Bump gajira-create to 1.0.4

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Create Jira issue
         if: steps.skip.outcome == 'skipped'
         id: create
-        uses: macuject/gajira-create@1.0.3
+        uses: macuject/gajira-create@1.0.4
         with:
           project: ${{ inputs.project }}
           issuetype: ${{ inputs.issue_type }}


### PR DESCRIPTION
## Description

Bumps `macuject/gajira-create` from `1.0.3` to `1.0.4` in the `create-jira-issue` workflow.

`1.0.3` included the source-level fix for the missing `fields` param in `getEpic` (PF-661), but the `dist/index.js` bundle was not rebuilt before tagging. Since GitHub Actions runs the bundled dist, the fix was never active. `1.0.4` includes the rebuilt dist.

**Blocked on**: macuject/gajira-create#43 being merged and a `1.0.4` release being cut.

Triggered by: https://github.com/macuject/platform/actions/runs/23418503354/job/68118719152

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating

🤖 Generated with [Claude Code](https://claude.com/claude-code)