### PR TITLE
feat(ci): add assign_reviewer input to create-jira-issue workflow

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: security, dependabot
         type: string
+      assign_reviewer:
+        description: Whether to assign a GitHub team member as PR reviewer. Set to false for dependabot minor/patch PRs where auto-merge is expected.
+        required: false
+        default: true
+        type: boolean
     secrets:
       JIRA_BASE_URL:
         required: true
@@ -93,7 +98,7 @@ jobs:
         shell: bash
 
       - name: Assign GH team member as reviewer # Assign a random member of the specified GitHub Org team as reviewer
-        if: steps.skip.outcome == 'skipped'
+        if: steps.skip.outcome == 'skipped' && inputs.assign_reviewer != false
         run: node reusable/.github/workflows/assign-reviewer.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +108,7 @@ jobs:
           EXCLUDE_MEMBERS: ${{ inputs.dependabot_exclude_team_members }}
 
       - name: Get PR reviewer # To be used to assign Jira issue to the same person
-        if: steps.skip.outcome == 'skipped'
+        if: steps.skip.outcome == 'skipped' && inputs.assign_reviewer != false
         id: get_reviewer
         run: | # Use the first reviewer request (PR not yet reviewed), or if none, the first review (PR already reviewed)
           reviewer_username=$(gh pr view ${{ github.event.pull_request.number }} --json reviewRequests --jq '.reviewRequests[0].login')
@@ -135,7 +140,7 @@ jobs:
           body: ${{ github.event.pull_request.body }}
           prlink: ${{ github.event.pull_request._links.html.href }}
           labels: ${{ inputs.labels }}
-          assignee: ${{ steps.get_reviewer.outputs.reviewer }}
+          assignee: ${{ inputs.assign_reviewer != false && steps.get_reviewer.outputs.reviewer || '' }}
           releaseBranches: ${{ steps.get_release_branch_names.outputs.release_branches }}
           githubJiraUserMap: ${{ vars.GH_JIRA_USER_MAP }}
 


### PR DESCRIPTION
## Description

Add optional `assign_reviewer` boolean input (default: `true`) to the `create-jira-issue.yml` reusable workflow.

When callers pass `assign_reviewer: false`, the workflow skips:
- GitHub reviewer assignment (the `assign-reviewer.mjs` step)
- PR reviewer lookup (the `get_reviewer` step)
- Jira issue assignee (passes empty string instead)

The Jira issue is still created, the PR is still renamed, and the issue is still transitioned through Ready → In Progress → In Review.

This enables downstream repos (`web`, `platform`) to defer reviewer assignment for dependabot minor/patch PRs where auto-merge is expected. Major bumps and non-dependabot PRs continue to assign reviewers as before.

**Backwards-compatible** — existing callers that don't pass the input get the default `true` behavior (no change).

**Downstream PRs:**
- macuject/web (WA-1985)
- macuject/platform (PF-749)

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating
