### PR TITLE
PF-805: Add reusable Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot Auto-Merge
+
+# Reusable workflow. Auto-merges minor/patch Dependabot PRs.
+#
+# Performs the merge using ORG_TEAM_MEMBERS rather than GITHUB_TOKEN so
+# that the resulting `pull_request: closed` event triggers downstream
+# workflows (specifically update-jira-issue.yml, which sets fixVersion
+# and transitions the linked Jira issue to Done). Merges performed by
+# GITHUB_TOKEN do not create new workflow runs — see
+# https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+
+on:
+  workflow_call:
+    secrets:
+      ORG_TEAM_MEMBERS:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch dependabot metadata
+        uses: dependabot/fetch-metadata@v2
+        id: metadata
+
+      - name: Enable auto-merge for minor/patch
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}


### PR DESCRIPTION
## Description

Adds a new reusable workflow at `.github/workflows/dependabot-auto-merge.yml` that auto-merges minor/patch Dependabot PRs using the `ORG_TEAM_MEMBERS` PAT instead of `GITHUB_TOKEN`.

### Why

Today, `platform` and `web` each have a local copy of `dependabot-auto-merge.yml` that performs the merge using `${{ github.token }}`. Per [GitHub's documented cycle-prevention rule](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), events created by `GITHUB_TOKEN` do not trigger new workflow runs. The `pull_request: closed` listener on each repo's `update-jira-issue.yml` (which calls the shared `update-jira-issue` reusable workflow that sets `fixVersion` and transitions the linked Jira ticket to Done) therefore never runs after an auto-merged Dependabot PR.

This is why **PF-804** (PR https://github.com/macuject/platform/pull/798, merged 2026-04-26) didn't appear in [release report 10788](https://macuject.atlassian.net/projects/PF/versions/10788/tab/release-report-all-issues) — the ticket has empty `fixVersion` and is still in "In Review". 47 PF tickets created since auto-merge launched (2026-03-23) are in the same state.

### What changes

- Adds reusable workflow that takes `ORG_TEAM_MEMBERS` as a required secret and performs the merge using it. `dependabot/fetch-metadata` continues to use the default `GITHUB_TOKEN` (read-only is sufficient).
- Follows the existing convention of `create-jira-issue.yml`, `update-jira-issue.yml`, etc. — a single reusable workflow consumed by every repo, rather than duplicated per-repo.

Follow-up PRs in `platform` (PF-805) and `web` (WA-2033) replace each repo's local `dependabot-auto-merge.yml` with a thin caller of this reusable workflow.

### Possible follow-up: rename `ORG_TEAM_MEMBERS`

Renaming would need to be done by @bradleybeddoes 

The secret name `ORG_TEAM_MEMBERS` originally reflected its sole use: looking up GitHub team membership (e.g. `garnertb/get-team-members`, `code-review.yml`'s reviewer lookup). Once this PR lands the same secret is also used to perform PR merges, which the name no longer describes. Worth a follow-up to rename it to something more general (e.g. `MACUJECT_AUTOMATION_TOKEN`) so future readers don't have to reverse-engineer the actual scope of use. Out of scope for this PR — renaming requires a coordinated update across all 9 consuming repos.

### Verification

End-to-end cascade test run on 2026-04-28 in `macuject/techteamresearch` confirmed `ORG_TEAM_MEMBERS`:

- Is a classic PAT (`ghp_`) with `repo, workflow` scopes.
- Has `admin` permission on the test repo.
- Triggers downstream `pull_request: closed` workflows when used to merge a PR (the cascade-prevention rule does not apply — only `GITHUB_TOKEN` is blocked).

Test branches have been deleted; nothing reached `main`.

## Breaking Changes

None. The reusable workflow is added but not yet consumed. Platform and web continue to use their existing local `dependabot-auto-merge.yml` files until the follow-up PRs land.

## Security

The merge step now uses a long-lived classic PAT (`ORG_TEAM_MEMBERS`) instead of the per-job `GITHUB_TOKEN`. The same PAT is already used in this org's `create-jira-issue.yml`, `update-jira-issue.yml`, and platform/web `code-review.yml` workflows for org-level reads. This PR expands its use to perform PR merges (which it already had `repo` scope to do).

The PAT is owned by Bradley. Single-owner risk: if rotated or revoked, all downstream workflows depending on it break simultaneously. Worth tracking as a follow-up — a dedicated GitHub App would be a more durable owner, but is out of scope here.

## Acceptance Testing

No UAT required. Behaviour will be observable on the next minor/patch Dependabot PR in `platform` after PF-805 (the platform caller PR) lands: the linked Jira ticket should transition to Done with `fixVersion` set automatically.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None — internal CI/automation tooling. Does not run in or affect production systems or customer data.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation — n/a
- [x] Documentation and diagram updates — n/a

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes — n/a
- [x] Job(s) — n/a
- [x] Security changes

[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating
