### PR TITLE
WA-2095: Gate Dependabot auto-merge on CI Gate success

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,11 @@
 name: Dependabot Auto-Merge
 
-# Reusable workflow. Auto-merges minor/patch Dependabot PRs.
+# Reusable workflow. Auto-merges minor/patch Dependabot PRs only after
+# the `CI Gate` check has succeeded on the PR's head commit.
+#
+# Triggered (in callers) by `workflow_run` on the CI workflow completing,
+# and by `pull_request_review` on review submission, so the merge fires
+# whichever signal arrives last: CI going green or the human approval.
 #
 # Performs the merge using ORG_TEAM_MEMBERS rather than GITHUB_TOKEN so
 # that the resulting `pull_request: closed` event triggers downstream
@@ -21,18 +26,116 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # Only run on CI success (workflow_run for a PR) or review submission.
+    # A failed CI run or a non-PR workflow_run is a no-op.
+    if: >-
+      (github.event_name == 'workflow_run' &&
+         github.event.workflow_run.conclusion == 'success' &&
+         github.event.workflow_run.event == 'pull_request') ||
+      github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch dependabot metadata
-        uses: dependabot/fetch-metadata@v2
-        id: metadata
-
-      - name: Enable auto-merge for minor/patch
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Resolve PR number
+        id: pr
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            NUM=$(jq -r '.workflow_run.pull_requests[0].number // empty' < "$GITHUB_EVENT_PATH")
+          else
+            NUM='${{ github.event.pull_request.number }}'
+          fi
+          if [ -z "$NUM" ] || [ "$NUM" = "null" ]; then
+            echo "No PR associated with this event; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Gate on author, review, mergeable, CI Gate
+        if: steps.pr.outputs.skip != 'true'
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          DATA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json author,reviewDecision,mergeable,state,headRefOid)
+          AUTHOR=$(jq -r '.author.login' <<<"$DATA")
+          REVIEW=$(jq -r '.reviewDecision' <<<"$DATA")
+          MERGEABLE=$(jq -r '.mergeable' <<<"$DATA")
+          STATE=$(jq -r '.state' <<<"$DATA")
+          SHA=$(jq -r '.headRefOid' <<<"$DATA")
+
+          echo "author=$AUTHOR review=$REVIEW mergeable=$MERGEABLE state=$STATE sha=$SHA"
+
+          if [ "$AUTHOR" != "app/dependabot" ]; then
+            echo "Not a Dependabot PR; skipping."
+            exit 0
+          fi
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR not open (state=$STATE); skipping."
+            exit 0
+          fi
+          if [ "$REVIEW" != "APPROVED" ]; then
+            echo "PR not approved (reviewDecision=$REVIEW); skipping."
+            exit 0
+          fi
+          if [ "$MERGEABLE" != "MERGEABLE" ]; then
+            echo "PR not mergeable (mergeable=$MERGEABLE); skipping."
+            exit 0
+          fi
+
+          # Verify CI Gate is success on the PR's head commit. Both triggers
+          # need this: workflow_run guarantees a green CI run existed, but
+          # the head SHA may have moved since; pull_request_review has no CI
+          # info at all and must look it up.
+          CONCL=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name=="CI Gate")] | sort_by(.completed_at) | last | .conclusion // "missing"')
+          if [ "$CONCL" != "success" ]; then
+            echo "CI Gate not success on $SHA (conclusion=$CONCL); skipping."
+            exit 0
+          fi
+
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Determine update type from Dependabot commit metadata
+        if: steps.gate.outputs.ok == 'true'
+        id: metadata
+        env:
+          GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Dependabot commits embed metadata in the commit message body:
+          #   update-type: version-update:semver-{patch,minor,major}
+          # Grouped PRs contain multiple entries; the effective type is the
+          # highest severity present (major > minor > patch).
+          MSGS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" --paginate \
+            --jq '.[].commit.message' | tr -d '\r')
+          TYPES=$(grep -oE 'update-type: version-update:semver-(patch|minor|major)' <<<"$MSGS" \
+            | awk -F'semver-' '{print $2}' | sort -u || true)
+          echo "Detected update types: $TYPES"
+          if grep -qx major <<<"$TYPES"; then
+            TYPE=major
+          elif grep -qx minor <<<"$TYPES"; then
+            TYPE=minor
+          elif grep -qx patch <<<"$TYPES"; then
+            TYPE=patch
+          else
+            TYPE=unknown
+          fi
+          echo "Effective update-type: $TYPE"
+          echo "update-type=$TYPE" >> "$GITHUB_OUTPUT"
+
+      - name: Merge minor/patch
+        if: >-
+          steps.metadata.outputs.update-type == 'minor' ||
+          steps.metadata.outputs.update-type == 'patch'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge --merge --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,8 @@
 name: Dependabot Auto-Merge
 
 # Reusable workflow. Auto-merges minor/patch Dependabot PRs only after
-# the `CI Gate` check has succeeded on the PR's head commit.
+# the caller's CI workflow (`inputs.workflow_name`, default `CI`) has
+# completed with `conclusion=success` on the PR head commit.
 #
 # Triggered (in callers) by `workflow_run` on the CI workflow completing,
 # and by `pull_request_review` on review submission, so the merge fires
@@ -16,6 +17,16 @@ name: Dependabot Auto-Merge
 
 on:
   workflow_call:
+    inputs:
+      workflow_name:
+        description: >-
+          Name of the CI workflow whose latest run on the PR head SHA must
+          have `conclusion=success` before a merge is allowed. The caller
+          should also list this workflow under `on.workflow_run.workflows`.
+          Defaults to `CI` to match `macuject/web`; `macuject/platform` and
+          other consumers with a differently named workflow must override.
+        type: string
+        default: CI
     secrets:
       ORG_TEAM_MEMBERS:
         required: true
@@ -88,14 +99,19 @@ jobs:
             exit 0
           fi
 
-          # Verify CI Gate is success on the PR's head commit. Both triggers
-          # need this: workflow_run guarantees a green CI run existed, but
-          # the head SHA may have moved since; pull_request_review has no CI
-          # info at all and must look it up.
-          CONCL=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name=="CI Gate")] | sort_by(.completed_at) | last | .conclusion // "missing"')
+          # Verify the latest run of the caller-specified CI workflow on
+          # the PR head SHA finished `success`. Both triggers need this:
+          # workflow_run guarantees one successful run existed, but the head
+          # SHA may have moved since; pull_request_review has no CI info and
+          # must look it up. Using the workflow's overall conclusion lets us
+          # support consumers without a dedicated aggregator check job — the
+          # conclusion is itself the aggregate (failure if any required job
+          # failed, success if all succeeded or were skipped).
+          WORKFLOW_NAME='${{ inputs.workflow_name }}'
+          CONCL=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$SHA&event=pull_request" \
+            --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\")] | sort_by(.run_started_at) | last | .conclusion // \"missing\"")
           if [ "$CONCL" != "success" ]; then
-            echo "CI Gate not success on $SHA (conclusion=$CONCL); skipping."
+            echo "Workflow '$WORKFLOW_NAME' not success on $SHA (conclusion=$CONCL); skipping."
             exit 0
           fi
 


### PR DESCRIPTION
## Description

[macuject/web#1761](https://github.com/macuject/web/pull/1761) auto-merged at `2026-05-13T23:36:28Z` while `CI / Build Docker Image` was still running. The build failed 31 seconds later and `CI / CI Gate` failed 39 seconds later, so every downstream test job skipped — yet the PR was already merged. This isn't a one-off: every recent Dependabot PR (#1761, #1770, #1773, #1775, #1777) merged with red or in-flight CI.

**Root cause.** `main` on macuject/web has no `required_status_checks` rule (verified via `gh api repos/macuject/web/branches/main/protection` → 404, and `gh api repos/macuject/web/rules/branches/main` returns only the `pull_request` rule from org ruleset `macuject/62481`). The current workflow calls `gh pr merge --auto --merge`, which delegates the wait-and-merge to GitHub's native auto-merge. Native auto-merge releases the merge once required reviews are satisfied **and** required status checks pass — with no required checks defined, the second condition is vacuously true, so the merge fires the instant approval lands. CI is not waited for.

**Fix.** Drop `--auto`. The workflow is now triggered (in callers) by `workflow_run` on the CI workflow completing **OR** `pull_request_review` on submission — whichever signal arrives last triggers the gated merge.

### Trigger vs gate — important distinction

The `OR` in the job-level `if:` is the **trigger** (when does the workflow wake up). The **merge condition** is the gate step inside the workflow, which independently verifies the caller's CI workflow finished `conclusion=success` on the current head SHA before calling `gh pr merge`. The gate is the source of truth:

```bash
# Verify the latest run of the caller-specified CI workflow on
# the PR head SHA finished `success`. Both triggers need this:
# workflow_run guarantees one successful run existed, but the head
# SHA may have moved since; pull_request_review has no CI info and
# must look it up. Using the workflow's overall conclusion lets us
# support consumers without a dedicated aggregator check job — the
# conclusion is itself the aggregate (failure if any required job
# failed, success if all succeeded or were skipped).
WORKFLOW_NAME='${{ inputs.workflow_name }}'
CONCL=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$SHA&event=pull_request" \
  --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\")] | sort_by(.run_started_at) | last | .conclusion // \"missing\"")
if [ "$CONCL" != "success" ]; then
  echo "Workflow '$WORKFLOW_NAME' not success on $SHA (conclusion=$CONCL); skipping."
  exit 0
fi
```

There is **no path** through this workflow that merges without `conclusion=success` on the current head SHA. `in_progress`, `failure`, `cancelled`, missing run → all exit without merging.

Walking through #1761 under the new logic:

1. Dependabot opens PR. CI starts. (Pre-existing `--auto` enablement is now a no-op because we don't use `--auto`.)
2. CI completes with `Build Docker Image` FAILED → `workflow_run.conclusion = 'failure'` → job-level `if:` is false → **workflow skipped**. No merge.
3. `github-actions` bot auto-approves (which it currently does even on red CI — a separate problem, harmless to us). `pull_request_review` fires → gate runs → looks up CI workflow conclusion on head SHA → `failure` → **skip, no merge**.

PR stays open and red. Exactly the desired behaviour.

### Why both triggers (why the OR is needed)

We don't know which event arrives last:

- **CI finishes after approval** (possible if a human approves while CI is running): `workflow_run` arrives second and runs the gate.
- **Approval comes after CI** (the actual macuject pattern, where `github-actions` auto-approves at the end): `pull_request_review` arrives second and runs the gate.

If we used **only `workflow_run`**, every PR in the recent batch would have fired the workflow once on CI completion — at which point the PR wasn't yet approved, so the gate would skip — and never fire again when approval lands. **No merges would ever happen.**

If we used **only `pull_request_review`**, the approval-during-CI race would skip and never re-fire. PRs would sit approved+green but never merge.

Both branches exist so whichever event arrives second triggers the gate. The gate is what keeps us safe; it never merges without CI success.

### `workflow_name` input

The gate uses `inputs.workflow_name` to know which CI workflow's conclusion to require. Default is `CI` (matches macuject/web). `macuject/platform` overrides it to `Macuject Infrastructure CI`. Using the workflow's overall conclusion (instead of a single named check-run like `CI Gate`) means consumers without a dedicated aggregator job — like platform — work without infrastructure changes.

### Other gate checks

Before merging, the workflow verifies:

- Author is `app/dependabot`
- PR is open + approved + mergeable
- Latest run of `inputs.workflow_name` on the PR head SHA has `conclusion=success`
- Dependabot's commit metadata declares an effective `semver-minor` or `semver-patch` update

Update-type is parsed directly from Dependabot's commit message metadata (`update-type: version-update:semver-*`) rather than via `dependabot/fetch-metadata@v2`, because the action reads from the `pull_request` event context and doesn't work on `workflow_run` / `pull_request_review`.

Manual UI merges by humans remain intentionally ungated.

Tracks [WA-2095](https://macuject.atlassian.net/browse/WA-2095).

## Breaking Changes

Callers must change their trigger from `on: pull_request_target` to:

```yaml
on:
  workflow_run:
    workflows: [<your CI workflow name>]
    types: [completed]
  pull_request_review:
    types: [submitted]
```

and pass `workflow_name` if it isn't `CI`. Two callers exist in the org and have paired PRs:

- [macuject/web#1781](https://github.com/macuject/web/pull/1781) — uses default `workflow_name: CI`
- [macuject/platform#835](https://github.com/macuject/platform/pull/835) — passes `workflow_name: Macuject Infrastructure CI` ([PF-874](https://macuject.atlassian.net/browse/PF-874))

Cross-repo dependency: this PR must merge first. Until each caller PR also merges, that repo's Dependabot auto-merge will fail safely — nothing will be merged with red CI.

## Security

This change tightens the merge gate: previously, Dependabot PRs could merge while CI was still running or had failed; after this change, they cannot merge unless the configured CI workflow finished `success` on the head SHA. This is a positive change to our deployment-integrity posture. No new credentials, secrets, or external endpoints introduced. Token usage (`ORG_TEAM_MEMBERS`) is unchanged.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: Medium

This workflow gates what merges to `main` across every consumer repo. A bug here could either (a) allow another broken merge to slip through — the failure mode this PR is fixing — or (b) deadlock Dependabot auto-merge entirely. Either outcome is correctable but visible in production CI behaviour, so this warrants careful review.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WA-2095]: https://macuject.atlassian.net/browse/WA-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ