### PR TITLE
MJ-2640: Retry reviewDecision check for eventual consistency

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -90,10 +90,31 @@ jobs:
             echo "PR not open (state=$STATE); skipping."
             exit 0
           fi
+
+          # reviewDecision may lag behind the actual review submission by
+          # several seconds due to GitHub API eventual consistency. When the
+          # trigger is pull_request_review we know a review was just submitted,
+          # so retry a few times before giving up. For workflow_run triggers
+          # the review happened earlier, so a single check suffices.
           if [ "$REVIEW" != "APPROVED" ]; then
-            echo "PR not approved (reviewDecision=$REVIEW); skipping."
-            exit 0
+            if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+              echo "reviewDecision not yet APPROVED; retrying (eventual consistency)..."
+              for i in 1 2 3; do
+                sleep 5
+                REVIEW=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                  --json reviewDecision --jq '.reviewDecision')
+                echo "  attempt $i: reviewDecision=$REVIEW"
+                if [ "$REVIEW" = "APPROVED" ]; then
+                  break
+                fi
+              done
+            fi
+            if [ "$REVIEW" != "APPROVED" ]; then
+              echo "PR not approved (reviewDecision=$REVIEW); skipping."
+              exit 0
+            fi
           fi
+
           if [ "$MERGEABLE" != "MERGEABLE" ]; then
             echo "PR not mergeable (mergeable=$MERGEABLE); skipping."
             exit 0


### PR DESCRIPTION
## Description

Fixes the dependabot auto-merge timing race. The auto-approve bot submits an approval (via PAT) within seconds of CI completing. This fires both auto-merge triggers near-simultaneously — `workflow_run` (CI done) and `pull_request_review` (approval submitted). Both check `reviewDecision`, but GitHub's API can lag several seconds behind the actual review submission, so both see `REVIEW_REQUIRED` and skip. With no retry or further events, the PR is stuck forever despite being approved with green CI.

Adds a retry loop (3 attempts, 5s apart) on the `pull_request_review` path, since we know a review was just submitted and the API just needs a moment to catch up. The `workflow_run` path is unchanged — if the approval hasn't been submitted yet, retrying won't help.

Currently affecting platform PRs #856, #857, #858, #859 — all approved, CI green, minor/patch, but never merged.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating