### PR TITLE
WA-2167: Retry mergeable check on UNKNOWN

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -115,6 +115,23 @@ jobs:
             fi
           fi
 
+          # mergeable is computed asynchronously by GitHub and briefly returns
+          # UNKNOWN after the head changes or CI completes (the merge state is
+          # recomputed in the background). When the workflow_run trigger fires
+          # right after CI finishes, we often hit this window. Retry on UNKNOWN
+          # only — CONFLICTING is terminal, retrying won't help.
+          if [ "$MERGEABLE" = "UNKNOWN" ]; then
+            echo "mergeable=UNKNOWN; retrying (eventual consistency)..."
+            for i in 1 2 3 4 5; do
+              sleep 5
+              MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                --json mergeable --jq '.mergeable')
+              echo "  attempt $i: mergeable=$MERGEABLE"
+              if [ "$MERGEABLE" != "UNKNOWN" ]; then
+                break
+              fi
+            done
+          fi
           if [ "$MERGEABLE" != "MERGEABLE" ]; then
             echo "PR not mergeable (mergeable=$MERGEABLE); skipping."
             exit 0


### PR DESCRIPTION
## Description

Fixes a dependabot auto-merge stall when GitHub's async `mergeable` field briefly returns `UNKNOWN`.

The reusable workflow checks `mergeable` once and bails immediately on anything other than `MERGEABLE`. GitHub computes the `mergeable` field asynchronously and recomputes it whenever the head SHA changes or CI status changes. When the `workflow_run` trigger fires right after CI finishes, we frequently hit a window where `mergeable=UNKNOWN`, the gate step exits, and no further events trigger the workflow — so the PR sits approved, CI green, and never merges.

Observed on [macuject/web PR #1823](https://github.com/macuject/web/pull/1823): three auto-merge attempts fired; the workflow_run-triggered one at 23:19 logged `author=app/dependabot review=APPROVED mergeable=UNKNOWN state=OPEN` and skipped. `mergeable` was `MERGEABLE` seconds later. Bradley noted ~3 other dependabot PRs in the same state.

Adds a retry loop on `mergeable=UNKNOWN` (5 attempts, 5s apart) mirroring the [MJ-2640](https://macuject.atlassian.net/browse/MJ-2640) retry for `reviewDecision`. `CONFLICTING` remains terminal — re-polling won't help.

The retry runs for both triggers (`pull_request_review` and `workflow_run`) because UNKNOWN can occur on either, though it's most common right after CI completes.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating

[MJ-2640]: https://macuject.atlassian.net/browse/MJ-2640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ