### PR TITLE
WA-2173: Sanitize PR title/body interpolation in reusable workflows

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -226,12 +226,14 @@ jobs:
           ((steps.mode.outputs.mode == 'full' && steps.create.outputs.issue != '') ||
            (steps.mode.outputs.mode == 'recovery' && steps.recover.outputs.key != ''))
         run: |
-          KEY="${{ steps.create.outputs.issue }}${{ steps.recover.outputs.key }}"
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --title "${KEY}: ${{ github.event.pull_request.title }}"
+          gh pr edit "$PR_NUMBER" \
+            --title "${KEY}: ${PR_TITLE}"
         working-directory: current_repo
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEY: ${{ steps.create.outputs.issue }}${{ steps.recover.outputs.key }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
 
       - name: Add Jira issue link as comment on PR
         if: steps.skip.outcome == 'skipped' && steps.mode.outputs.mode == 'full'

--- a/.github/workflows/transition-jira-to-in-review.yml
+++ b/.github/workflows/transition-jira-to-in-review.yml
@@ -45,9 +45,10 @@ jobs:
     steps:
       - name: Extract issue key from branch name
         id: extract_key
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PROJECT: ${{ inputs.project }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          PROJECT="${{ inputs.project }}"
           ISSUE_KEY=$(echo "$BRANCH" | grep -oE "${PROJECT}-[0-9]+" | head -1)
           if [[ -z "$ISSUE_KEY" ]]; then
             echo "::warning::No Jira issue key found in branch name: $BRANCH"

--- a/.github/workflows/update-jira-issue.yml
+++ b/.github/workflows/update-jira-issue.yml
@@ -31,13 +31,14 @@ jobs:
 
       - name: Extract issue key and project key from pull request title
         id: extract_keys
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          title="${{ github.event.pull_request.title }}"
           # Extract issue key (first part before the first colon)
-          issue_key=$(echo "$title" | cut -d ':' -f1)
+          issue_key=$(echo "$PR_TITLE" | cut -d ':' -f1)
 
           # Extract project key (first part before the first '-')
-          project_key=$(echo "$title" | cut -d '-' -f1)
+          project_key=$(echo "$PR_TITLE" | cut -d '-' -f1)
 
           echo "issue_key=$issue_key" >> $GITHUB_OUTPUT
           echo "project_key=$project_key" >> $GITHUB_OUTPUT
@@ -124,10 +125,10 @@ jobs:
     steps:
       - name: Validate pull request title
         id: validate_pr_title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          ESCAPED_PR_TITLE=$(echo $PR_TITLE | sed 's/"/\\"/g')
-          if [[ "$ESCAPED_PR_TITLE" =~ ^\[?([A-Z]{2,4}-[0-9]{2,5}(,[[:space:]])?)+\]?:|^([A-Z]{2,4}-[0-9]{2,5}): ]]; then
+          if [[ "$PR_TITLE" =~ ^\[?([A-Z]{2,4}-[0-9]{2,5}(,[[:space:]])?)+\]?:|^([A-Z]{2,4}-[0-9]{2,5}): ]]; then
             echo "PR title is valid"
           else
             echo "Invalid PR title format. It should start with a Jira issue key."
@@ -149,11 +150,11 @@ jobs:
 
       - name: Extract issue key from pull request title
         id: extract_keys
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          title="${{ github.event.pull_request.title }}"
-
           # Extract issue key (first part before the first colon)
-          issue_key=$(echo "$title" | cut -d ':' -f1)
+          issue_key=$(echo "$PR_TITLE" | cut -d ':' -f1)
 
           # Extract project key (first part before the first '-') and remove leading '[' if present (e.g. '[WA-42, WA-23]')
           project_key=$(echo "$issue_key" | cut -d '-' -f1 | sed 's/^\[//')


### PR DESCRIPTION
## Description

Five steps across the reusable workflows interpolate user-controlled fields (PR title, head ref) directly into bash via GitHub Actions templating:

```yaml
run: |
  PR_TITLE="${{ github.event.pull_request.title }}"
  ...
```

When a PR title contains literal double quotes, the rendered bash breaks: the embedded `"` terminates the assignment early and the remainder is interpreted as a command.

Observed on [platform run 26209188249](https://github.com/macuject/platform/actions/runs/26209188249/job/77115812196): PR title `PF-873: Composite "service unhealthy" alarms + flapping coverage verification` caused `update-jira-issue.yml`'s validate-pr-title step to fail with `unhealthy alarms + flapping coverage verification: command not found` (exit 127). Job halted, Jira not transitioned.

Same pattern is also a (low-risk here — trusted PR authors) shell-injection vector that GitHub's [security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) explicitly recommends against.

## Fix

Replace direct templating with `env:` pass-through at all five sites:

- `update-jira-issue.yml` ×3 (`PR_TITLE`)
- `create-jira-issue.yml` ×1 (`PR_TITLE`, `KEY`, `PR_NUMBER`)
- `transition-jira-to-in-review.yml` ×1 (`BRANCH`, `PROJECT`)

Also dropped the now-unnecessary `ESCAPED_PR_TITLE=$(echo $PR_TITLE | sed 's/"/\\"/g')` line in `validate_pr_title` — that workaround only existed to compensate for the unsafe interpolation it replaces, and a) didn't actually defend the assignment (the original `PR_TITLE="..."` line already broke before sed could run), b) becomes obsolete now that the string never touches the script source.

The other two steps in `update-jira-issue.yml` that already used `env:` (the `comment-on-jira-issue.mjs` env block) are left untouched — they were already correct.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: Low

This is internal CI tooling (no patient data path), but it does close a script-injection vector — listing as Low rather than None on that basis.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating