### PR TITLE
WA-2180: Guard process-existing-pr label against duplicate Jira tickets

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -47,7 +47,9 @@ jobs:
     steps:
       # Two paths run here:
       #   full     — create a new Jira issue, transition it, assign reviewer, rename PR, comment.
-      #              Fires on a dependabot 'opened' event, or on a non-dependabot 'labeled with process-existing-pr' event.
+      #              Fires on a dependabot 'opened' event, or on a non-dependabot 'labeled with process-existing-pr' event
+      #              where the PR title does not already start with the project key (prevents duplicate tickets when the
+      #              label is applied to an already-processed PR).
       #   recovery — dependabot stripped the Jira prefix from a previously-renamed PR via force-push.
       #              Recover the existing key from the workflow's prior "Associated Jira issue" comment and re-apply the prefix.
       #              Fires on a dependabot 'synchronize' event when the PR title no longer starts with the project key.
@@ -55,7 +57,7 @@ jobs:
       - name: Skip remaining steps # Run this rather than just skipping the whole job, so that we see a green tick in the PR checks
         if: >- # Specificity is important here to avoid triggering this action multiple times when Dependabot creates then labels a PR
           !((github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'opened') ||
-            (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'process-existing-pr') ||
+            (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'process-existing-pr' && !startsWith(github.event.pull_request.title, format('{0}-', inputs.project))) ||
             (github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'synchronize' && !startsWith(github.event.pull_request.title, format('{0}-', inputs.project))))
         id: skip
         run: echo "Run not needed for this PR, skipping remaining steps"


### PR DESCRIPTION
## Description

Applying the `process-existing-pr` label to a PR whose title already starts with the project key (e.g. `WA-2160: …`) currently re-runs the full path of this workflow and mints a **second** Jira ticket, prepending it to the title.

**Concrete incident:** [macuject/web#1821](https://github.com/macuject/web/pull/1821) was opened by Dependabot, the workflow created [WA-2160](https://macuject.atlassian.net/browse/WA-2160) and renamed the title. Five days later the `process-existing-pr` label was applied; the workflow ran again, minted [WA-2179](https://macuject.atlassian.net/browse/WA-2179) (now closed as duplicate), and the title became `WA-2179: WA-2160: Bump …`.

### Root cause

In `.github/workflows/create-jira-issue.yml`, the labeled branch of the skip condition was:

```yaml
(github.actor != 'dependabot[bot]' && github.event.action == 'labeled' && github.event.label.name == 'process-existing-pr')
```

It had no check that the title was missing the project prefix. The recovery (dependabot `synchronize`) branch already had this guard: `!startsWith(github.event.pull_request.title, format('{0}-', inputs.project))`.

### Change

Add the same `!startsWith(title, '<project>-')` guard to the labeled branch so the workflow no-ops when the PR title already starts with the project key. Also update the path-description comment so the gating is clear to future readers.

The full path remains exactly the same for PRs that genuinely need retroactive processing (i.e. no Jira prefix in the title yet).

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: None

This change affects internal CI/CD tooling only (a reusable GitHub Actions workflow that creates Jira issues for PRs). No production code, no patient data, no user-facing surface, and no security posture changes.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WA-2160]: https://macuject.atlassian.net/browse/WA-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WA-2179]: https://macuject.atlassian.net/browse/WA-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ