### PR TITLE
WA-2214: Escalate auto-approved Dependabot PRs to a human when CI fails

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,6 +14,15 @@ name: Dependabot Auto-Merge
 # and transitions the linked Jira issue to Done). Merges performed by
 # GITHUB_TOKEN do not create new workflow runs — see
 # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+#
+# A second job, `escalate-on-ci-failure`, handles the inverse case: when CI
+# *fails* on a Dependabot PR that automation already auto-approved (Claude
+# labelled it `claude-auto-merge-candidate` and posted an auto-approval review
+# before CI completed), the merge job above is a no-op and the PR would sit
+# orphaned — approved by a bot, red CI, no human looking. This job dismisses the
+# stale approval and routes the PR to a human reviewer. It only runs when the
+# caller passes `team_slug`, so consumers opt in by adding that input to their
+# wrapper (no breakage for callers that haven't adopted it yet).
 
 on:
   workflow_call:
@@ -27,6 +36,16 @@ on:
           other consumers with a differently named workflow must override.
         type: string
         default: CI
+      team_slug:
+        description: >-
+          GitHub team (slug under `macuject`) whose members are eligible
+          reviewers when the `escalate-on-ci-failure` job routes an
+          auto-approved Dependabot PR to a human after CI fails. Optional:
+          when empty (the default) the escalation job is skipped entirely, so
+          existing callers keep working until they opt in by setting this.
+          e.g. `web`, `Platform`.
+        type: string
+        default: ""
     secrets:
       ORG_TEAM_MEMBERS:
         required: true
@@ -193,3 +212,107 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: gh pr merge --merge --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"
+
+  escalate-on-ci-failure:
+    # Inverse of the merge job: when the caller's CI workflow completes with
+    # `conclusion=failure` on a Dependabot PR that automation already
+    # auto-approved, dismiss the stale approval and route the PR to a human.
+    # Gated on `team_slug` so callers opt in (see header comment). Skipped for
+    # CI successes and non-PR runs (the merge job handles successes).
+    if: >-
+      inputs.team_slug != '' &&
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          set -euo pipefail
+          NUM=$(jq -r '.workflow_run.pull_requests[0].number // empty' < "$GITHUB_EVENT_PATH")
+          if [ -z "$NUM" ] || [ "$NUM" = "null" ]; then
+            echo "No PR associated with this event; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Escalate to human reviewer
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ORG_TEAM_MEMBERS }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+          TEAM_SLUG: ${{ inputs.team_slug }}
+        run: |
+          set -euo pipefail
+
+          DATA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,state,labels)
+          AUTHOR=$(jq -r '.author.login' <<<"$DATA")
+          STATE=$(jq -r '.state' <<<"$DATA")
+          LABELS=$(jq -c '[.labels[].name]' <<<"$DATA")
+
+          # Only act on open Dependabot PRs that automation took ownership of
+          # (Claude applied the auto-merge candidate label) and that we have not
+          # already escalated. The sentinel label makes this idempotent: a PR
+          # whose CI fails repeatedly is escalated once, not on every red run.
+          if [ "$AUTHOR" != "app/dependabot" ]; then
+            echo "Not a Dependabot PR (author=$AUTHOR); skipping."; exit 0
+          fi
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR not open (state=$STATE); skipping."; exit 0
+          fi
+          if ! jq -e 'index("claude-auto-merge-candidate")' <<<"$LABELS" >/dev/null; then
+            echo "PR not an auto-merge candidate (automation never took ownership); skipping."
+            exit 0
+          fi
+          if jq -e 'index("auto-merge-ci-failed")' <<<"$LABELS" >/dev/null; then
+            echo "PR already escalated (auto-merge-ci-failed present); skipping."; exit 0
+          fi
+
+          echo "CI failed on auto-approved Dependabot PR #$PR_NUMBER — escalating to human review."
+
+          # 1. Dismiss the stale automated approval so the PR is no longer
+          #    APPROVED. This prevents the merge job from ever merging on a
+          #    stale approval if CI later goes green on a force-push, and forces
+          #    a fresh human approval. There should be one APPROVED review (the
+          #    org PAT's auto-approval); dismiss any that exist.
+          REVIEW_IDS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+            --jq '.[] | select(.state == "APPROVED") | .id')
+          for id in $REVIEW_IDS; do
+            echo "Dismissing stale approval review $id"
+            gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/reviews/$id/dismissals" \
+              -f message="Auto-approval dismissed: CI failed after auto-approval. This PR needs human review." \
+              -f event=DISMISS >/dev/null
+          done
+
+          # 2. Assign a human reviewer from the caller's team, excluding the PR
+          #    author. The author guard is defensive: a Dependabot PR's author
+          #    is never a team member, but it keeps selection correct if a team
+          #    member ever opens a PR that reaches this path.
+          if ! MEMBERS=$(gh api "orgs/macuject/teams/$TEAM_SLUG/members" --jq '.[].login' 2>&1); then
+            echo "::warning::Failed to fetch members of team '$TEAM_SLUG'"
+            MEMBERS=""
+          fi
+          ELIGIBLE=$(grep -vxF "$AUTHOR" <<<"$MEMBERS" || true)
+          SELECTED=$(grep -v '^$' <<<"$ELIGIBLE" | shuf -n 1 || true)
+          if [ -n "$SELECTED" ]; then
+            echo "Assigning $SELECTED as reviewer"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer "$SELECTED"
+          else
+            echo "No eligible individual reviewer; requesting team '$TEAM_SLUG'"
+            gh api -X POST "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+              --input - <<< "{\"team_reviewers\":[\"$TEAM_SLUG\"]}" \
+              || echo "::warning::Failed to request team review"
+          fi
+
+          # 3. Comment, then 4. add the sentinel label (idempotency guard above).
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "⚠️ Auto-merge cancelled: CI failed after this Dependabot PR was auto-approved. The automated approval has been dismissed and the PR routed to a human reviewer. Please review the CI failure and the changes before merging."
+
+          gh label create "auto-merge-ci-failed" --repo "$REPO" \
+            --color "B60205" \
+            --description "Auto-merge cancelled because CI failed after auto-approval; escalated to human review" \
+            --force >/dev/null 2>&1 || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "auto-merge-ci-failed"


### PR DESCRIPTION
## Description

When Claude auto-approves a minor/patch Dependabot PR (label `claude-auto-merge-candidate`), the auto-approval review is posted **before** CI completes — the approval comment even says "Auto-merge will proceed once CI Gate passes." If CI then **fails**, the existing `auto-merge` job correctly does nothing (it gates on CI success), but nothing else happens: the PR sits orphaned — approved by a bot, red CI, no human looking at it (e.g. [macuject/web#1837](https://github.com/macuject/web/pull/1837)).

The root cause is that the human-escalation path in each consumer's `code-review.yml` runs **once at review time** and never reacts to CI *outcome*.

This adds an `escalate-on-ci-failure` job to the reusable workflow that fires when the caller's CI workflow completes with `conclusion=failure` on such a PR. It:

1. **Dismisses the stale automated approval** (so the PR is no longer `APPROVED` and can't auto-merge on a later green CI without fresh human eyes);
2. **Assigns a human reviewer** from the caller's team ((shuffle-and-pick, excluding the PR author)) — falling back to a team review request;
3. **Comments** explaining auto-merge was cancelled;
4. **Adds an `auto-merge-ci-failed` sentinel label** so a PR whose CI fails repeatedly is escalated only once.

A new **optional** input drives it: `team_slug` (which team to pull reviewers from). The job is **skipped entirely unless `team_slug` is set**, so this is backwards compatible — existing callers keep working unchanged until they opt in by adding the input to their wrapper. Consumer wrappers are updated separately: `macuject/web` (this same ticket, WA-2214) and `macuject/platform` (PF-988).

## Security

This strengthens an existing CI guardrail rather than weakening it: it ensures an auto-approved dependency PR that fails CI can no longer linger with a stale bot approval, and forces a fresh human review before merge. It reuses the existing `ORG_TEAM_MEMBERS` PAT and the workflow's existing `pull-requests: write` permission; no new secrets or permissions are introduced. No Information Security Officer review is considered necessary.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: Medium

This is an org-wide reusable workflow consumed by every repo's CI, governing how dependency PRs are merged. The change is additive and opt-in, but because it touches org-wide merge automation it warrants a Medium rating.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating
