### PR TITLE
WA-2218: Classify Dependabot indirect-dependency bumps for auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -191,6 +191,33 @@ jobs:
             --jq '.[].commit.message' | tr -d '\r')
           TYPES=$(grep -oE 'update-type: version-update:semver-(patch|minor|major)' <<<"$MSGS" \
             | awk -F'semver-' '{print $2}' | sort -u || true)
+
+          # Dependabot omits the `update-type:` metadata line for *indirect*
+          # (transitive) dependency bumps — the commit body only carries
+          # `dependency-name`, `dependency-version`, and `dependency-type:
+          # indirect` (see macuject/web#1835). Derive the classification from
+          # the `Bumps [name](url) from X.Y.Z to A.B.C.` lines Dependabot
+          # always emits, and union with any signal already extracted so
+          # grouped PRs that mix direct and indirect entries pick the highest
+          # severity across both. Pre-release/non-numeric version components
+          # are skipped (rare for indirect deps; falls through to `unknown`).
+          PAIRS=$(grep -oE 'Bumps .+ from [0-9]+\.[0-9]+\.[0-9]+ to [0-9]+\.[0-9]+\.[0-9]+' <<<"$MSGS" || true)
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            OLD=$(awk '{for(i=1;i<=NF;i++) if($i=="from"){print $(i+1); exit}}' <<<"$line")
+            NEW=$(awk '{for(i=1;i<=NF;i++) if($i=="to"){print $(i+1); exit}}' <<<"$line")
+            [[ "$OLD" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+            IFS=. read -r OM OI OP <<<"$OLD"
+            IFS=. read -r NM NI NP <<<"$NEW"
+            if [ "$NM" -gt "$OM" ]; then
+              TYPES="$TYPES"$'\n'major
+            elif [ "$NM" = "$OM" ] && [ "$NI" -gt "$OI" ]; then
+              TYPES="$TYPES"$'\n'minor
+            elif [ "$NM" = "$OM" ] && [ "$NI" = "$OI" ] && [ "$NP" -gt "$OP" ]; then
+              TYPES="$TYPES"$'\n'patch
+            fi
+          done <<< "$PAIRS"
+          TYPES=$(printf '%s\n' "$TYPES" | sort -u | grep -v '^$' || true)
           echo "Detected update types: $TYPES"
           if grep -qx major <<<"$TYPES"; then
             TYPE=major


### PR DESCRIPTION
Stacked on: #88

## Description

When Dependabot bumps an **indirect** dependency (one that isn't listed directly in `package.json` but gets pulled in by another package), it leaves out the line in the commit message that tells us whether the change is patch, minor, or major. Without that signal, the auto-merge workflow can't tell what kind of bump it is and skips the merge step — so the PR sits open even though it's safe to merge.

[macuject/web#1835](https://github.com/macuject/web/pull/1835) is a good example: `tmp 0.2.4 → 0.2.6`, an indirect patch bump. Everything else passed (Dependabot author, approved, mergeable, CI green) but the merge step never ran because the bump type came out as `unknown`.

This PR teaches the workflow a second way to figure out the bump type. Dependabot always writes a `Bumps [name] from X.Y.Z to A.B.C.` line in the commit body — even for indirect bumps. The new code reads that line, compares the old and new version numbers itself, and classifies the bump. The result is combined with whatever the existing parser found:

- **Direct-dep PRs (the common case):** both methods agree and nothing about the outcome changes.
- **Indirect-dep PRs like #1835:** the new method fills in the answer the existing one couldn't, and auto-merge can proceed.
- **Grouped PRs that mix direct and indirect deps:** the highest-severity bump across both kinds is used, so e.g. an indirect major can't be hidden behind a direct minor.

Pre-release versions (like `1.0.0-beta`) aren't handled — those skip the new check and fall through to `unknown` as before.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: Medium

Same rationale as #88 — this is the shared workflow that every repo uses to merge dependency PRs. The change is small and only fills in cases that previously came out as `unknown`, but it touches every repo's dependency-merge automation, so Medium.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating