### PR TITLE
WA-2221: Bump org workflow actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Checkout code
         if: steps.skip.outcome == 'skipped'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Fetch all history so that we can get the release branch names
@@ -119,16 +119,16 @@ jobs:
 
       - name: Checkout code from macuject/.github repo
         if: steps.skip.outcome == 'skipped' && steps.mode.outputs.mode == 'full'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: macuject/.github
           path: reusable
 
       - name: Setup Node.js
         if: steps.skip.outcome == 'skipped' && steps.mode.outputs.mode == 'full'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         if: steps.skip.outcome == 'skipped' && steps.mode.outputs.mode == 'full'

--- a/.github/workflows/rename-pr.yml
+++ b/.github/workflows/rename-pr.yml
@@ -22,16 +22,16 @@ jobs:
       # & check if PR title starts with Jira issue key
       - name: Checkout code from macuject/.github repo
         if: steps.skip.outcome == 'skipped'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: macuject/.github
           path: reusable
 
       - name: Setup Node.js
         if: steps.skip.outcome == 'skipped'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         if: steps.skip.outcome == 'skipped'
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout code from current repo
         if: >-
           steps.skip.outcome == 'skipped'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-jira-issue.yml
+++ b/.github/workflows/update-jira-issue.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Checkout code
         if: steps.validate_key.outputs.valid == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Fetch all history so that we can get the release branch names
@@ -88,16 +88,16 @@ jobs:
 
       - name: Checkout code from macuject/.github repo
         if: steps.validate_key.outputs.valid == 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: macuject/.github
           path: reusable
 
       - name: Setup Node.js
         if: steps.validate_key.outputs.valid == 'true'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         if: steps.validate_key.outputs.valid == 'true'
@@ -168,7 +168,7 @@ jobs:
           echo "Project key: ${{ steps.extract_keys.outputs.project_key }}"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # Fetch all history so that we can get the release branch names
@@ -190,15 +190,15 @@ jobs:
         run: rm -rf current_repo
 
       - name: Checkout code from macuject/.github repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           repository: macuject/.github
           path: reusable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         run: npm install node-fetch dotenv form-data
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR about manual Jira transition
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Description

Bump the Node-20-era GitHub Actions in this org repo to their current Node-24 majors, ahead of GitHub forcing Node 24 on **2026-06-02** and removing Node 20 entirely on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

This is the third PR in a series tracked under [WA-2221](https://macuject.atlassian.net/browse/WA-2221) — the other two land in `macuject/web` ([#1857](https://github.com/macuject/web/pull/1857) for the same official-action bumps over there, and [#1858](https://github.com/macuject/web/pull/1858) to let Dependabot surface future runtime-related majors automatically).

### Changes

| Action / input | Old | New | Notes |
| --- | --- | --- | --- |
| `actions/checkout` | `@v3` | `@v6` | 8 uses across the three workflow files |
| `actions/setup-node` | `@v3` | `@v6` | 4 uses |
| `node-version` | `18` | `24` | 4 uses — matches the new runner default |
| `actions/github-script` | `@v7` | `@v8` | 1 use in `update-jira-issue.yml` |

No workflow logic changes. All inputs in use (`token`, `repository`, `path`, `fetch-depth`, `node-version`, inline `script:`) are preserved across the bumped majors. The four `.mjs` automation scripts (`check-issue-key.mjs`, `comment-on-jira-issue.mjs`, `release-version.mjs`, `assign-reviewer.mjs`) only use stable Node APIs that remain available on Node 24.

### Cross-repo impact

These workflows are `workflow_call` reusables consumed by other macuject repos (web, platform, etc.). Callers don't set Node version, so the bump is transparent to them. The workflow contracts (inputs, secrets, outputs) are unchanged.

### Known follow-ups (out of scope)

Spotted during the audit but explicitly **not** addressed here to keep this PR atomic:

- `comment-on-jira-issue.mjs` calls `response.buffer()` (a `node-fetch` v2 API) on an unpinned `npm install node-fetch`. If a v3 resolution were ever returned this would already be broken today, independent of the Node runtime.
- `check-issue-key.mjs` still uses the deprecated `::set-output` workflow command (deprecated since 2022 but not yet hard-removed).
- Third-party action pins (`atlassian/gajira-login@v3`, `atlassian/gajira-transition@v3`, `garnertb/get-team-members@v1`, `macuject/gajira-create@1.0.4`) need their own Node 24 readiness audit before 2026-09-16.

Happy to spin these into separate tickets if useful.

## Impact Assessment

As part of our ongoing commitment to maintaining compliance with SOC 2 and HIPAA regulations, each proposed change should have an impact assessment undertaken.

> **Before selecting a rating, please review the [Impact Assessment Rating][impact assessment] guide for detailed criteria and examples.**

- **High**: Potential for significant harm to sensitive data or user access and material adverse impact on Macuject's operations or reputation.
- **Medium**: Potential for moderate harm to sensitive data or user access and adverse impact on Macuject's operations or reputation.
- **Low**: Unlikely to significantly harm sensitive data or user access, and no expected material adverse impact on Macujects's operations or reputation.
- **None**: Changes that are not relevant to the impact assessment process. Changes will not be used in production by Macuject customers and are related to internal tooling, documentation, or other non-production systems.

**Impact Assessment for this PR**: Low

Tooling/workflow change only. These reusable workflows handle Jira issue creation, PR renaming, and Jira commenting on merge — they don't run production code and don't touch patient data. Worst case is one of the consumer repos sees a workflow failure that is caught immediately and is easy to roll back.

## Checklist

I've considered all of the following and added to the proposed changes where relevant to this PR:

- [x] Comments for complex or unclear sections
- [x] Logging to assist production operation
- [x] Documentation and diagram updates (e.g. Confluence pages, local markdown docs, architecture diagrams)

I've considered all of the following and added details to the PR description where relevant:

- [x] Breaking changes
- [x] UAT guidance
- [x] Data-related changes
- [x] Job(s) have been described and a [PR opened][job process] for the platform team to review
- [x] Security changes. This also requires the Macuject Information Security Officer to be added to this PR as an additional reviewer.

[job process]: https://macuject.atlassian.net/wiki/spaces/TT/pages/1705082972/Automated+Jobs
[impact assessment]: https://macuject.atlassian.net/wiki/spaces/TT/pages/2382036993/Impact+Assessment+Rating

[WA-2221]: https://macuject.atlassian.net/browse/WA-2221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ